### PR TITLE
Remove Symfony as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/symfony": ">=2.3.0",
         "symfony/event-dispatcher": ">=2.3.0",
         "symfony/swiftmailer-bundle": ">=2.2.2"
     },


### PR DESCRIPTION
Otherwise it prevents installing for systems that use Symfony components separately, with different version numbers.
For example, Mautic: https://github.com/mautic/mautic/blob/staging/composer.json .